### PR TITLE
47 | Update publish workflow to include .whl

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -4,13 +4,65 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  publish:
+
+  build-whl:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        python: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        exclude:
+          - os: windows-latest
+            python: "3.14"
+          - os: macos-latest
+            python: "3.8"
+          - os: macos-latest
+            python: "3.7"
+          - os: ubuntu-latest
+            python: "3.7"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python 3.14 with pyenv (if needed)
+        if: ${{ matrix.python == '3.14' }}
+        run: |
+          curl https://pyenv.run | bash
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init --path)"
+          eval "$(pyenv init -)"
+          pyenv install 3.14-dev
+          pyenv global 3.14-dev
+
+      - name: Setup Python
+        if: ${{ matrix.python != '3.14' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install build tools
+        run: pip install build twine wheel
+
+      - name: Build wheel
+        run: python -m build --wheel
+
+      - name: Upload built packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkg-${{ matrix.os }}-${{ matrix.python }}-${{ strategy.job-index }}
+          path: |
+            ./dist/*.whl
+
+  build-sdist:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
@@ -19,11 +71,33 @@ jobs:
       - name: Install build tools
         run: pip install build twine wheel
 
-      - name: Build package
-        run: python -m build
+      - name: Build source distribution
+        run: python -m build --sdist
 
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*.tar.gz
+      - name: Upload built packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkg-sdist
+          path: |
+            ./dist/*.tar.gz
+
+  publish:
+    needs: [build-whl, build-sdist]
+    runs-on: ubuntu-latest
+
+    environment:
+      name: release
+      url: https://pypi.org/project/flask-inputfilter
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download built packages
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,14 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+[0.4.2] - 2025-04-25
+--------------------
+
+Added
+^^^^^
+- .whl generation for all major versions and envs.
+
+
 [0.4.1] - 2025-04-24
 --------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,7 +1,7 @@
 project = "flask-inputfilter"
 copyright = "2025, Leander Cain Slotosch"
 author = "Leander Cain Slotosch"
-release = "0.4.1"
+release = "0.4.2"
 
 extensions = ["sphinx_rtd_theme", "sphinx_design"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flask_inputfilter"
-version = "0.4.1"
+version = "0.4.2"
 description = "A library to easily filter and validate input data in Flask applications"
 readme = "README.rst"
 requires-python = ">=3.7"

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,21 @@ from setuptools import setup
 
 if shutil.which("g++") is not None:
     from Cython.Build import cythonize
+    from setuptools.extension import Extension
+
+    pyx_modules = [
+        "flask_inputfilter.Mixin._ExternalApiMixin",
+        "flask_inputfilter.Model._FieldModel",
+        "flask_inputfilter._InputFilter",
+    ]
 
     ext_modules = cythonize(
-        [
-            "flask_inputfilter/Mixin/_ExternalApiMixin.pyx",
-            "flask_inputfilter/Model/_FieldModel.pyx",
-            "flask_inputfilter/_InputFilter.pyx",
-        ],
+        module_list=[Extension(
+            name=module,
+            sources=[module.replace('.', '/') + ".pyx"],
+            extra_compile_args=["-std=c++11"],
+            language="c++"
+        ) for module in pyx_modules],
         language_level=3,
     )
     options = {


### PR DESCRIPTION
Fixes #47 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the CI/CD pipeline by updating GitHub workflows to support both wheel and source distribution builds. It refines the build and publish process with new concurrency settings and expanded build matrices, while updating documentation for the 0.4.2 release and aligning package configuration files with the updated version.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>