### PR TITLE
Pin cibuildwheel version to allow py 3.7 publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -24,7 +24,7 @@ jobs:
           python-version: 3.11
 
       - name: Install build tools
-        run: python -m pip install cibuildwheel
+        run: python -m pip install cibuildwheel==2.13.1
 
       - name: Build wheel with cibuildwheel
         env:
@@ -53,7 +53,7 @@ jobs:
           python-version: 3.11
 
       - name: Install build tools
-        run: python -m pip install cibuildwheel
+        run: python -m pip install cibuildwheel==2.13.1
 
       - name: Build wheel (manylinux-aarch64)
         env:
@@ -82,7 +82,7 @@ jobs:
           python-version: 3.11
 
       - name: Install build tools
-        run: python -m pip install cibuildwheel
+        run: python -m pip install cibuildwheel==2.13.1
 
       - name: Build wheel (musllinux-aarch64)
         env:


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request updates the GitHub Actions workflow for publishing to PyPI by pinning cibuildwheel to version 2.13.1, ensuring compatibility with Python 3.11. The changes enhance the reliability of the build process across multiple workflow steps.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>